### PR TITLE
Fixed link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SUGGESTR
-###Try it at suggestr.mybluemix.net [](suggestr.mybluemix.net)  
+###Try it at [suggestr.mybluemix.net](http://suggestr.mybluemix.net)  
 
 Suggestr is a convenient, web-based course suggester centered around feature richness and usability.
 


### PR DESCRIPTION
Without http://, Github resolves the link to a directory in your repo
